### PR TITLE
Check empty "line" array

### DIFF
--- a/lib/topojson/topology.js
+++ b/lib/topojson/topology.js
@@ -108,24 +108,27 @@ module.exports = function(objects, Q) {
       p = t;
     }
 
-    for (var i = 0; i <= n; ++i) {
-      var point = line[(i + k) % n],
-          x = (point[0] - x0) * kx | 0,
-          y = (point[1] - y0) * ky | 0,
-          j = y * Q + x,
-          p = coincidences[j];
-      if (!equal(p, t)) {
-        var tInP = t.every(function(line) { return p.indexOf(line) >= 0; }),
-            pInT = p.every(function(line) { return t.indexOf(line) >= 0; });
-        if (tInP) a.push(j);
-        arc(a);
-        if (!tInP && !pInT) arc([a[a.length - 1], j]);
-        if (pInT) a = [a[a.length - 1]];
-        else a = [];
-      }
-      if (a[a.length - 1] !== j) a.push(j); // skip duplicate points
-      t = p;
-    }
+//console.log(line);
+	if(line.length>0){
+	    for (var i = 0; i <= n; ++i) {
+	      var point = line[(i + k) % n],
+	          x = (point[0] - x0) * kx | 0,
+	          y = (point[1] - y0) * ky | 0,
+        	  j = y * Q + x,
+	          p = coincidences[j];
+	      if (!equal(p, t)) {
+	        var tInP = t.every(function(line) { return p.indexOf(line) >= 0; }),
+	            pInT = p.every(function(line) { return t.indexOf(line) >= 0; });
+	        if (tInP) a.push(j);
+	        arc(a);
+	        if (!tInP && !pInT) arc([a[a.length - 1], j]);
+	        if (pInT) a = [a[a.length - 1]];
+	        else a = [];
+	     }
+	     if (a[a.length - 1] !== j) a.push(j); // skip duplicate points
+	     t = p;
+	   }
+	}
 
     arc(a);
 


### PR DESCRIPTION
Hi Mike,
It turned out the script fails in the case of empty "line" arrays. I made a small check for that, now my geojson file compiles.

```
topojson/lib/topojson/topology.js:114
          x = (point[0] - x0) * kx | 0,
                    ^
TypeError: Cannot read property '0' of undefined
```

Empty lines usually don't happen. My test geojson was coming from shapefile which was simplified using MapShaper, so probably this might happen more then once.
