### PR TITLE
Option to keep certain or all feature properties

### DIFF
--- a/bin/topojson
+++ b/bin/topojson
@@ -31,6 +31,11 @@ var argv = optimist
       describe: "name of feature property to promote to geometry id",
       default: null
     })
+    .options("p", {
+      alias: "properties",
+      describe: "names of feature properties to keep (no name keeps all properties)",
+      default: null
+    })
     .options("help", {
       describe: "display this helpful message",
       default: false
@@ -57,7 +62,7 @@ argv._.forEach(function(file) {
 });
 
 // Convert GeoJSON to TopoJSON.
-object = topojson.topology(objects, +argv.q);
+object = topojson.topology(objects, +argv.q, argv.properties);
 
 // Simplify.
 if (+argv.s > 0) topojson.simplify(object, +argv.s);

--- a/lib/topojson/topology.js
+++ b/lib/topojson/topology.js
@@ -3,7 +3,7 @@ var type = require("./type");
 var π = Math.PI,
     radians = π / 180;
 
-module.exports = function(objects, Q) {
+module.exports = function(objects, Q, properties) {
   var x0 = Infinity,
       y0 = Infinity,
       x1 = -Infinity,
@@ -81,6 +81,14 @@ module.exports = function(objects, Q) {
     Feature: function(feature) {
       this.geometry(feature.geometry);
       feature.geometry.id = feature.id;
+      if (properties) {
+        if (properties === true) {
+          feature.geometry.properties = feature.properties;
+        } else {
+          feature.geometry.properties = {};
+          [].concat(properties).forEach(function(p) { feature.geometry.properties[p] = feature.properties[p]; });
+        }
+      }
       return feature.geometry;
     },
 


### PR DESCRIPTION
I added the option to keep certain or all feature properties (default is to keep none).

Usage:

```
topojson in.json -o out.json --properties  # keeps all properties
topojson in.json -o out.json -p foo        # keeps property 'foo'
topojson in.json -o out.json -p foo -p bar # keeps properties 'foo' and 'bar'
```

For example, I want to use this for https://github.com/interactivethings/swiss-maps, where it would be useful to keep properties like the municipality name, canton number etc.

Cheers,
Jeremy
