### PR TITLE
Do not assume topology options have quantization and force-clockwise

### DIFF
--- a/lib/topojson/topology.js
+++ b/lib/topojson/topology.js
@@ -19,11 +19,14 @@ module.exports = function(objects, options) {
       arcs = [],
       arcsByIndex = [];
 
-  if (arguments.length > 1)
-    Q = +options["quantization"],
-    cw = !!options["force-clockwise"],
+  if (arguments.length > 1) {
+    if (options.hasOwnProperty("quantization"))
+      Q = +options["quantization"];
+    if (options.hasOwnProperty("force-clockwise"))
+      cw = !!options["force-clockwise"];
     id = options["id"] || id,
     propertyFilter = options["property-filter"] || propertyFilter;
+  }
 
   function each(callback) {
     var t = type(callback), o = {};


### PR DESCRIPTION
Closes issue #16

It makes use of Object.prototype.hasOwnProperty, which although less elegant should be the faster way to check for the presence of a property in an object (not needing to scan hierarchy)
