### PR TITLE
Optimise and fix triangle area calculation.

### DIFF
--- a/lib/topojson/simplify.js
+++ b/lib/topojson/simplify.js
@@ -118,8 +118,8 @@ function area(t) {
       sy0 = Math.sin(y = p0[1] * radians), cy0 = Math.cos(y),
       sy1 = Math.sin(y = p1[1] * radians), cy1 = Math.cos(y),
       sy2 = Math.sin(y = p2[1] * radians), cy2 = Math.cos(y),
-      a = .5 * Math.acos(Math.max(-1, Math.min(1, sy0 * sy1 + cy0 * cy1 * Math.cos(x1 - x0)))),
-      b = .5 * Math.acos(Math.max(-1, Math.min(1, sy1 * sy2 + cy1 * cy2 * Math.cos(x2 - x1)))),
-      c = .5 * Math.acos(Math.max(-1, Math.min(1, sy2 * sy0 + cy2 * cy0 * Math.cos(x0 - x2))));
-  return 4 * Math.atan(Math.sqrt(Math.tan(a + b + c) * Math.tan(b + c) * Math.tan(a + c) * Math.tan(a + b)));
+      a = sy0 * sy1 + cy0 * cy1 * Math.cos(x1 - x0),
+      b = sy1 * sy2 + cy1 * cy2 * Math.cos(x2 - x1),
+      c = sy2 * sy0 + cy2 * cy0 * Math.cos(x0 - x2);
+  return 2 * Math.atan2(Math.sqrt(Math.max(0, 1 + 2 * a * b * c - a * a - b * b - c * c)), 1 + a + b + c);
 }


### PR DESCRIPTION
When investigating possible optimisations, I realised that I had made an
error in my original implementation using l’Huillier.  The error was
that s = a + b + c should have been s = (a + b + c) / 2.  The s stands
for semiperimeter!

As a result, the areas were slightly inflated, but not catastrophically
enough for us to notice by eye.

This fix is an optimised implementation using a formula due to van
Oosterom and Strackee (1983).
