### PR TITLE
Improve area accuracy for small polygons.

### DIFF
--- a/lib/topojson/simplify.js
+++ b/lib/topojson/simplify.js
@@ -111,15 +111,21 @@ function transformRelative(transform) {
 }
 
 function area(t) {
-  var p0 = t[0], p1 = t[1], p2 = t[2], y,
-      x0 = p0[0] * radians,
-      x1 = p1[0] * radians,
-      x2 = p2[0] * radians,
-      sy0 = Math.sin(y = p0[1] * radians), cy0 = Math.cos(y),
-      sy1 = Math.sin(y = p1[1] * radians), cy1 = Math.cos(y),
-      sy2 = Math.sin(y = p2[1] * radians), cy2 = Math.cos(y),
-      a = sy0 * sy1 + cy0 * cy1 * Math.cos(x1 - x0),
-      b = sy1 * sy2 + cy1 * cy2 * Math.cos(x2 - x1),
-      c = sy2 * sy0 + cy2 * cy0 * Math.cos(x0 - x2);
-  return 2 * Math.atan2(Math.sqrt(Math.max(0, 1 + 2 * a * b * c - a * a - b * b - c * c)), 1 + a + b + c);
+  var a = distance(t[0], t[1]),
+      b = distance(t[1], t[2]),
+      c = distance(t[2], t[0]),
+      s = (a + b + c) / 2;
+  return 4 * Math.atan(Math.sqrt(Math.tan(s / 2) * Math.tan((s - a) / 2) * Math.tan((s - b) / 2) * Math.tan((s - c) / 2)));
+}
+
+function distance(a, b) {
+  var Δλ = (b[0] - a[0]) * radians,
+      sinΔλ = Math.sin(Δλ),
+      cosΔλ = Math.cos(Δλ),
+      sinφ0 = Math.sin(a[1] * radians),
+      cosφ0 = Math.cos(a[1] * radians),
+      sinφ1 = Math.sin(b[1] * radians),
+      cosφ1 = Math.cos(b[1] * radians),
+      _;
+  return Math.atan2(Math.sqrt((_ = cosφ1 * sinΔλ) * _ + (_ = cosφ0 * sinφ1 - sinφ0 * cosφ1 * cosΔλ) * _), sinφ0 * sinφ1 + cosφ0 * cosφ1 * cosΔλ);
 }


### PR DESCRIPTION
The use of cosines can introduce large rounding errors for small distances.

Fixes #28.
