### PR TITLE
Add new --simplify-proportion option.

### DIFF
--- a/bin/topojson
+++ b/bin/topojson
@@ -29,6 +29,11 @@ var argv = optimist
       describe: "precision threshold for Visvalingam simplification, in steradians",
       default: 0,
     })
+    .options("n", {
+      alias: "simplify-proportion",
+      describe: "proportion of points to retain for Visvalingam simplification",
+      default: 1,
+    })
     .options("id-property", {
       describe: "name of feature property to promote to geometry id",
       default: null
@@ -79,7 +84,7 @@ object = topojson.topology(objects, {
 });
 
 // Simplify.
-if (+argv.s > 0) topojson.simplify(object, +argv.s);
+if (+argv.s > 0 || +argv.n > 0) topojson.simplify(object, +argv.s, +argv.n);
 
 // Output JSON.
 var json = JSON.stringify(object);

--- a/lib/topojson/simplify.js
+++ b/lib/topojson/simplify.js
@@ -3,7 +3,7 @@ var minHeap = require("./min-heap");
 var π = Math.PI,
     radians = π / 180;
 
-module.exports = function(topology, minArea) {
+module.exports = function(topology, minArea, retainProportion) {
   var heap = minHeap(),
       maxArea = 0,
       triangle,
@@ -58,8 +58,18 @@ module.exports = function(topology, minArea) {
     }
   }
 
+  if (retainProportion) {
+    var areas = [];
+    topology.arcs.forEach(function(arc) {
+      arc.forEach(function(point) {
+        areas.push(point.area);
+      });
+    });
+    minArea = areas.sort(areaCompare)[Math.ceil((N - 1) * retainProportion)];
+  }
+
   topology.arcs = topology.arcs.map(function(arc) {
-    return arc.filter(function(point, i) {
+    return arc.filter(function(point) {
       return point.area >= minArea;
     });
   });
@@ -115,7 +125,7 @@ function area(t) {
       b = distance(t[1], t[2]),
       c = distance(t[2], t[0]),
       s = (a + b + c) / 2;
-  return 4 * Math.atan(Math.sqrt(Math.tan(s / 2) * Math.tan((s - a) / 2) * Math.tan((s - b) / 2) * Math.tan((s - c) / 2)));
+  return 4 * Math.atan(Math.sqrt(Math.max(0, Math.tan(s / 2) * Math.tan((s - a) / 2) * Math.tan((s - b) / 2) * Math.tan((s - c) / 2))));
 }
 
 function distance(a, b) {
@@ -129,3 +139,5 @@ function distance(a, b) {
       _;
   return Math.atan2(Math.sqrt((_ = cosφ1 * sinΔλ) * _ + (_ = cosφ0 * sinφ1 - sinφ0 * cosφ1 * cosΔλ) * _), sinφ0 * sinφ1 + cosφ0 * cosφ1 * cosΔλ);
 }
+
+function areaCompare(a, b) { return b - a; }


### PR DESCRIPTION
This allows the proportion of retained points to be specified for
simplification, which may be friendlier than specifying an exact area.

This also includes a fix for NaN areas that were occurring due to small
negative values in the triangle area calculation (being passed to sqrt).
