### PR TITLE
Fix winding order detection for large polygons.

### DIFF
--- a/lib/topojson/spherical.js
+++ b/lib/topojson/spherical.js
@@ -17,8 +17,7 @@ function formatDistance(radians) {
 
 function ringArea(ring) {
   if (!ring.length) return 0;
-  var u = 1,
-      v = 0,
+  var area = 0,
       p = ring[0],
       λ = p[0] * radians,
       φ = p[1] * radians / 2 + π_4,
@@ -36,19 +35,15 @@ function ringArea(ring) {
         cosφ = Math.cos(φ),
         sinφ = Math.sin(φ),
         k = sinφ0 * sinφ,
-        u0 = u,
-        v0 = v,
-        u1 = cosφ0 * cosφ + k * Math.cos(dλ),
-        v1 = k * Math.sin(dλ);
-    // ∑ arg(z) = arg(∏ z), where z = u + iv.
-    u = u0 * u1 - v0 * v1;
-    v = v0 * u1 + u0 * v1;
+        u = cosφ0 * cosφ + k * Math.cos(dλ),
+        v = k * Math.sin(dλ);
+    area += Math.atan2(v, u);
 
     // Advance the previous point.
     λ0 = λ, cosφ0 = cosφ, sinφ0 = sinφ;
   }
 
-  return 2 * Math.atan2(v, u);
+  return 2 * area;
 }
 
 function absoluteArea(a) {

--- a/test/spherical-ringArea-test.js
+++ b/test/spherical-ringArea-test.js
@@ -14,6 +14,9 @@ suite.addBatch({
     },
     "small counterclockwise area": function(area) {
       assert.inDelta(area([[0, -.5], [1, -.5], [1, .5], [0, .5], [0, -.5]]), -0.0003046212, 1e-10);
+    },
+    "large clockwise rectangle": function(area) {
+      assert.inDelta(area([[-170, 80], [0, 80], [170, 80], [170, -80], [0, -80], [-170, -80], [-170, 80]]), 11.8575249632, 1e-10);
     }
   }
 });


### PR DESCRIPTION
The trick to avoid atan2 calls fails for winding order detection in the
case where a counter-clockwise area strays into a positive quadrant
(similarly for a clockwise area straying into a negative quadrant).
