### PR TITLE
Remove points from arcs that are [0,0]

### DIFF
--- a/lib/topojson/simplify.js
+++ b/lib/topojson/simplify.js
@@ -1,21 +1,26 @@
 var minHeap = require("./min-heap"),
-    systems = require("./coordinate-systems");
+    systems = require("./coordinate-systems"),
+    type = require("./type");
 
 module.exports = function(topology, options) {
   var mininumArea = 0,
       retainProportion,
+      allowEmpty = false,
       verbose = false,
       heap = minHeap(),
       maxArea = 0,
       system = null,
       triangle,
       N = 0,
-      M = 0;
+      M = 0,
+      G = 0,
+      D = 0;
 
   if (options)
     "minimum-area" in options && (mininumArea = +options["minimum-area"]),
     "coordinate-system" in options && (system = systems[options["coordinate-system"]]),
     "retain-proportion" in options && (retainProportion = +options["retain-proportion"]),
+    "allow-empty" in options && (allowEmpty = !!options["allow-empty"]),
     "verbose" in options && (verbose = !!options["verbose"]);
 
   topology.arcs.forEach(function(arc) {
@@ -77,16 +82,117 @@ module.exports = function(topology, options) {
     if (verbose) console.warn("simplification: effective minimum area " + mininumArea.toPrecision(3));
   }
 
-  topology.arcs = topology.arcs.map(function(arc) {
-    return arc.filter(function(point) {
-      return point.area >= mininumArea;
-    });
-  });
+  topology.arcs = topology.arcs
+    .map(function(arc) {
+      return arc.filter(function(point) {
+        return point.area >= mininumArea;
+      });
+    })
 
   topology.arcs.forEach(function(arc) {
     arc.forEach(transformRelative(topology.transform));
     M += arc.length;
   });
+
+  if (!allowEmpty) {
+    // Remove arcs of length 0. This changes the array indices, so all
+    // geometries need to be updated.
+    var arcIndexMap = []; // arcIndexMap[originalArcId] => newArcId or null
+    var newArcs = [];
+
+    // Remove all (0, 0) points.
+    // Beware: this may break the user's assumption that area==Infinity at
+    // the end of each arc.
+    topology.arcs = topology.arcs.map(function(arc) {
+      return arc.filter(function(point, i) {
+        return i == 0 || (point[0] || point[1]);
+      });
+    });
+
+    topology.arcs.forEach(function(arc) {
+      if (arc.length == 1) {
+        // arc has zero length; cull it
+        arcIndexMap.push(null);
+      } else {
+        // it's a non-empty arc
+        arcIndexMap.push(newArcs.length);
+        newArcs.push(arc);
+      }
+    });
+    topology.arcs = newArcs;
+
+    // Update arcs, and delete objects that have none left
+    function updateArcList(arcList) {
+      return arcList
+        .map(function(arcIndex) {
+          if (arcIndex < 0) {
+            return ~arcIndexMap[~arcIndex];
+          } else {
+            return arcIndexMap[arcIndex];
+          }
+        })
+        .filter(function(arcIndex) { return arcIndex !== null });
+    }
+    function updateArcListList(arcListList) {
+      // e.g., a MultiLineString or Polygon
+      return arcListList
+        .map(function(arcList) { return updateArcList(arcList); })
+        .filter(function(arcList) { return arcList.length > 0; });
+    }
+    function updateArcListListList(arcListListList) {
+      // MultiPolygon is funky, and so is this function name
+      return arcListListList
+        .map(function(arcListList) { return updateArcListList(arcListList); })
+        .filter(function(arcListList) { return arcListList.length > 0; });
+    }
+    function maybeMarkGeometryForPruning(geometry) {
+      if (geometry.arcs.length == 0) {
+        D += 1;
+        geometry.type = null;
+        delete geometry.arcs;
+      }
+    }
+    function filterGeometry(geometry, complexity) {
+      G += 1;
+      switch (complexity) {
+        case 1:
+          geometry.arcs = updateArcList(geometry.arcs);
+          break;
+        case 2:
+          geometry.arcs = updateArcListList(geometry.arcs);
+          break;
+        case 3:
+          geometry.arcs = updateArcListListList(geometry.arcs);
+          break;
+      }
+      maybeMarkGeometryForPruning(geometry);
+    }
+
+    filter = type({
+      LineString: function(geometry) { filterGeometry(geometry, 1); },
+      MultiLineString: function(geometry) { filterGeometry(geometry, 2); },
+      MultiPolygon: function(geometry) { filterGeometry(geometry, 3); },
+      Polygon: function(geometry) { filterGeometry(geometry, 2); },
+      MultiPoint: function() {},
+      Point: function() {},
+      GeometryCollection: function(collection) {
+        this.defaults.GeometryCollection.call(this, collection);
+        collection.geometries = collection.geometries.filter(function(geometry) { return geometry.type != null; });
+        if (!collection.geometries.length) {
+          collection.type = null;
+          delete collection.geometries;
+        }
+      }
+    });
+
+    var objectsToDelete = [];
+    for (var k in topology.objects) {
+      var object = topology.objects[k];
+      filter.object(object);
+      if (object.type === null) objectsToDelete.push(k);
+    }
+    objectsToDelete.forEach(function(k) { delete topology.objects[k]; });
+  }
 
   function update(triangle) {
     heap.remove(triangle);
@@ -94,7 +200,7 @@ module.exports = function(topology, options) {
     heap.push(triangle);
   }
 
-  if (verbose) console.warn("simplification: retained " + M + " / " + N + " points (" + Math.round((M / N) * 100) + "%)");
+  if (verbose) console.warn("simplification: retained " + M + " / " + N + " points (" + Math.round((M / N) * 100) + "%) and " + (G - D) + " / " + G + " geometries");
 
   return topology;
 };

--- a/test/simplify-test.js
+++ b/test/simplify-test.js
@@ -1,0 +1,112 @@
+var vows = require("vows"),
+    assert = require("./assert"),
+    topojson = require("../");
+
+var suite = vows.describe("topojson.simplify");
+
+// simplify() adds an "area" property to each point in an arc. We need to
+// remove those properties to make assert.deepEqual() work.
+function removeAreaFromArcs(arcs) {
+  return arcs.map(function(arc) {
+    return arc.map(function(p) {
+      return p.slice(0);
+    });
+  });
+}
+
+suite.addBatch({
+  "simplify": {
+    topic: function() {
+      return topojson.simplify;
+    },
+    "excess points are removed": function() {
+      var topology = {
+        transform: { scale: [ 1, 1 ], translate: [ 0, 0 ] },
+        objects: {},
+        arcs: [[
+          // *
+          // **
+          // * *
+          // *  *
+          // *   *
+          // *    *
+          // *     *
+          // *      *
+          // *       *
+          // *        *
+          // *---__    **
+          //       ````*
+          //
+          // We expect this to become a normal triangle.
+          [0, 0],      // 0,0
+          [10, 10],    // 10,10
+          [0, 1],      // 10,11
+          [1, -1],     // 11,10
+          [-11, 0],   // 0,10
+          [0, -10]     // 0,0
+        ]]
+      };
+      topojson.simplify(topology, {
+        "minimum-area": 2,
+        "coordinate-system": "cartesian",
+      });
+      assert.deepEqual(
+        removeAreaFromArcs(topology.arcs),
+        [[[0, 0], [10, 10], [-10, 0], [0, -10]]]
+      );
+    },
+
+    "empty arcs are removed": function() {
+      var topology = {
+        transform: { scale: [ 1, 1 ], translate: [ 0, 0 ] },
+        objects: {},
+        arcs: [[[ 50, 50 ], [1, 1], [-1, -1]]]
+      };
+      topojson.simplify(topology, {
+        "minimum-area": 3,
+        "coordinate-system": "cartesian"
+      });
+      assert.deepEqual(topology.arcs, []);
+    },
+
+    "arc IDs are rearranged when empty arcs are removed": function() {
+      var topology = {
+        transform: { scale: [ 1, 1 ], translate: [ 0, 0 ] },
+        objects: {
+          a: { type: "LineString", arcs: [ 0, 1, 2 ] }
+        },
+        arcs: [
+          [[0, 0], [10, 0]],
+          [[10, 0], [1, 1], [-1, -1]], // a useless arc which will be removed
+          [[10, 0], [0, 10]]
+        ]
+      };
+      topojson.simplify(topology, {
+        "minimum-area": 1,
+        "coordinate-system": "cartesian"
+      });
+      assert.deepEqual(topology.objects.a.arcs, [ 0, 1 ]);
+    },
+
+    "Geometries with no more arcs are removed": function() {
+      var topology = {
+        transform: { scale: [ 1, 1 ], translate: [ 0, 0 ] },
+        objects: {
+          a: { type: "GeometryCollection", geometries: [
+          	{ type: "Polygon", arcs: [[ 0 ]] }
+		  ]}
+        },
+        arcs: [
+          [[10, 0], [1, 1], [-1, -1]] // a useless arc which will be removed
+        ]
+      };
+      topojson.simplify(topology, {
+        "minimum-area": 1,
+        "coordinate-system": "cartesian"
+      });
+      assert.deepEqual(topology.objects, {});
+    }
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
In a production topology, I found that simplify() often leaves [0,0] points within arcs. Those are, of course, useless. But removing them opens a whole can of worms:
- All of this should only happen if --allow-empty is not set.
- If the [0,0] occurs in the middle of an arc, it's easy to remove
- If the [0,0] occurs as the first coordinate of the arc, that's of course fine since (since it's an absolute point, not a relative one)
- If the [0,0] occurs as the final coordinate of the arc, then it should be removed ... right? Should we worry if `arc[arc.length -1].area != Infinity`?
- If the arc is a two-point arc and the [0,0] occurs as the second point, the entire arc should be deleted. That means we need to walk the tree to change all arc IDs.
- If a geometry loses all its arcs, the geometry should be deleted.

Agree?

I've left the code rather monolithic to check for agreement first. I hope it's readable enough for a general yay/nay. If you prefer to give some higher-level suggesions rather than comb through the code, feel free. (Should it be a separate object/file/etc?)
