### PR TITLE
Ensure cartesian areas are positive in pixels.

### DIFF
--- a/lib/topojson/cartesian.js
+++ b/lib/topojson/cartesian.js
@@ -16,7 +16,7 @@ function ringArea(ring) {
   while (++i < n) {
     area += ring[i - 1][1] * ring[i][0] - ring[i - 1][0] * ring[i][1];
   }
-  return area * .5;
+  return -area * .5; // ensure clockwise pixel areas are positive
 }
 
 function triangleArea(triangle) {

--- a/test/cartesian-ringArea-test.js
+++ b/test/cartesian-ringArea-test.js
@@ -1,0 +1,21 @@
+var vows = require("vows"),
+    assert = require("assert"),
+    cartesian = require("../lib/topojson/cartesian");
+
+var suite = vows.describe("topojson.cartesian.ringArea");
+
+suite.addBatch({
+  "ringArea": {
+    topic: function() {
+      return cartesian.ringArea;
+    },
+    "clockwise area is positive": function(area) {
+      assert.ok(area([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]) > 0);
+    },
+    "counterclockwise area is negative": function(area) {
+      assert.ok(area([[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]) < 0);
+    }
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
When we say "Cartesian" we really mean screen pixels, in which case the
vertical y-axis origin is at the top, not the bottom as in conventional
mathematical notation.  This affects the sign of the area calculation.

Forcing clockwise winding order in screen pixels requires us to change
the area sign to ensure that positive areas mean clockwise winding order
for both spherical and Cartesian coordinate systems.
