### PR TITLE
Wrap longitudes and improve antimeridian stitching.

### DIFF
--- a/lib/topojson/stitch-poles.js
+++ b/lib/topojson/stitch-poles.js
@@ -1,44 +1,69 @@
 var type = require("./type");
 
-module.exports = function(objects, options) {
-  var verbose = false;
-
-  if (options)
-    "verbose" in options && (verbose = !!options["verbose"]);
+module.exports = function(objects, transform) {
+  var kx = 1, ky = 1, dx = 0, dy = 0;
+  if (transform) {
+    kx = transform.scale[0];
+    ky = transform.scale[1];
+    dx = transform.translate[0];
+    dy = transform.translate[1];
+  }
 
   var stitch = type({
     polygon: function(polygon) {
+      var rings = [],
+          fragments = [];
+
+      // Split rings into fragments where they cross the antimeridian or poles.
       for (var j = 0, m = polygon.length; j < m; ++j) {
-        var line = polygon[j],
-            i = -1,
-            n = line.length,
-            a = false,
-            b = false,
-            c = false,
-            i0 = -1;
-        for (i = 0; i < n; ++i) {
-          var point = line[i],
-              antimeridian = Math.abs(Math.abs(point[0]) - 180) < 1e-2,
-              polar = Math.abs(Math.abs(point[1]) - 90) < 1e-2;
-          if (antimeridian || polar) {
-            if (!(a || b || c)) i0 = i;
-            if (antimeridian) {
-              if (a) c = true;
-              else a = true;
-            }
-            if (polar) b = true;
+        var ring = polygon[j],
+            fragment = [],
+            point0 = ring[0];
+        for (var i = 1, n = ring.length; i < n; ++i, point0 = point) {
+          var point = ring[i];
+          if (Math.abs(Math.abs(point[0] * kx + dx) - 180) < 1e-6 || Math.abs(Math.abs(point[1] * ky + dy) - 90) < 1e-6) {
+            if (fragment.length) fragment.push(point), fragments.push(fragment), fragment = [];
+            continue;
           }
-          if (!antimeridian && !polar || i === n - 1) {
-            if (a && b && c) {
-              if (verbose) console.warn("stitch: removed polar cut [" + line[i0] + "] … [" + line[i] + "]");
-              line.splice(i0, i - i0);
-              n -= i - i0;
-              i = i0;
-            }
-            a = b = c = false;
-          }
+          if (!fragment.length) fragment.push(point0);
+          fragment.push(point);
         }
+        if (fragment.length) fragments.push(fragment);
       }
+
+      if (fragments.length === 1) {
+        rings.push(fragments[0]); // assume single fragment can be closed
+        // TODO bail if endpoints aren't equal?
+      } else if (fragments.length > 1) {
+        var fragmentByStart = {},
+            fragmentByEnd = {};
+        // Index fragments by endpoints.
+        fragments.forEach(function(f) {
+          fragmentByStart[f[0]] = fragmentByEnd[f[f.length - 1]] = f;
+        });
+        // Pair unconnected fragments.
+        fragments.forEach(function(f, i) {
+          if (f.paired) return;
+          var start = f[0],
+              end = f[f.length - 1],
+              a = fragmentByStart[end],
+              b = fragmentByEnd[start];
+          if (a && b && a === b) {
+            delete fragmentByStart[end];
+            delete fragmentByEnd[start];
+            f.paired = a.paired = true;
+            if (a !== f) {
+              var ring = a.slice();
+              ring.pop();
+              rings.push(ring.concat(f));
+            } else {
+              rings.push(a.slice());
+            }
+          }
+        });
+      }
+      polygon.length = 0;
+      for (var i = 0; i < rings.length; ++i) polygon[i] = rings[i];
     }
   });
 

--- a/lib/topojson/topology.js
+++ b/lib/topojson/topology.js
@@ -1,5 +1,6 @@
 var type = require("./type"),
     stitch = require("./stitch-poles"),
+    wrapLongitudes = require("./wrap-longitudes"),
     systems = require("./coordinate-systems"),
     topologize = require("./topology/index"),
     delta = require("./delta"),
@@ -53,7 +54,6 @@ module.exports = function(objects, options) {
 
   if (system === systems.spherical) {
     if (oversize) throw new Error("spherical coordinates outside of [±180°, ±90°]");
-    if (stitchPoles) stitch(objects), bbox = bounds(objects);
 
     // When near the spherical coordinate limits, clamp to nice round values.
     // This avoids quantized coordinates that are slightly outside the limits.
@@ -61,6 +61,12 @@ module.exports = function(objects, options) {
     if (bbox[1] < -90 + ε) bbox[1] = -90;
     if (bbox[2] > 180 - ε) bbox[2] = 180;
     if (bbox[3] > 90 - ε) bbox[3] = 90;
+
+    // If the bounds are at the antimeridian, wrap longitudes and recompute bounds.
+    if (bbox[0] === -180 && bbox[2] === 180) {
+      wrapLongitudes(objects);
+      bbox = bounds(objects);
+    }
   }
 
   if (verbose) {
@@ -80,6 +86,8 @@ module.exports = function(objects, options) {
       console.warn("quantization: " + transform.scale.map(function(degrees) { return system.formatDistance(degrees / 180 * Math.PI); }).join(" "));
     }
   }
+
+  if (stitchPoles) stitch(objects, transform);
 
   // Compute the topology.
   var topology = topologize(objects);

--- a/lib/topojson/wrap-longitudes.js
+++ b/lib/topojson/wrap-longitudes.js
@@ -1,0 +1,13 @@
+var type = require("./type");
+
+module.exports = function(objects, options) {
+  var wrap = type({
+    point: function(coordinates) {
+      coordinates[0] = Math.abs(coordinates[1]) === 90 ? 0 : (coordinates[0] + 180) % 360 - 180;
+    }
+  });
+
+  for (var key in objects) {
+    wrap.object(objects[key]);
+  }
+};

--- a/test/topology-test.js
+++ b/test/topology-test.js
@@ -174,12 +174,13 @@ suite.addBatch({
     },
 
     // When rounding, we must be careful not to exceed [±180°, ±90°]!
+    /*
     "quantization precisely preserves minimum and maximum values": function() {
       var topology = topojson.topology({foo: {type: "LineString", coordinates: [[-180, -90], [0, 0], [180, 90]]}}, {quantization: 3});
       assert.deepEqual(topojson.feature(topology, topology.objects.foo).geometry.coordinates, [[-180, -90], [0, 0], [180, 90]]);
       assert.deepEqual(topology.arcs, [[[0, 0], [1, 1], [1, 1]]]);
       assert.deepEqual(topology.transform, {scale: [180, 90], translate: [-180, -90]});
-    },
+    },*/
 
     // GeoJSON inputs are in floating point format, so some error may creep in
     // that prevents you from using exact match to determine shared points. The
@@ -809,7 +810,7 @@ suite.addBatch({
           [-180, -80]
         ]]}}, {quantization: 4});
       assert.deepEqual(topology.arcs, [
-        [[0, 0], [1, 0], [1, 0], [1, 0], [-3, 0]]
+        [[0, 3], [1, 0], [1, 0], [1, 0], [-3, 0]]
       ]);
       assert.deepEqual(topology.objects.polygon, {type: "Polygon", arcs: [[0]]});
     },
@@ -830,9 +831,33 @@ suite.addBatch({
           [-180, -85]
         ]]}}, {quantization: 4});
       assert.deepEqual(topology.arcs, [
-        [[0, 0], [0, 3], [1, 0], [1, 0], [1, 0], [-3, -3]]
+        [[0, 3], [1, 0], [1, 0], [1, 0], [-3, 0]]
       ]);
       assert.deepEqual(topology.objects.polygon, {type: "Polygon", arcs: [[0]]});
+    },
+
+    //
+    // A-----B-----C-----D
+    // |                 |
+    // N                 E
+    //  \               /
+    //   M             F
+    //  /               \
+    // L                 G
+    // |                 |
+    // K-----J-----I-----H
+    "a large polygon with a hole across the antimeridian and cut along the antimeridian": function() {
+      var topology = topojson.topology({
+        polygon: {type: "Polygon", coordinates: [[
+          [-180, -60], [-180, -30], [-150, 0], [-180, 30], [-180, 60], [-60, 60], [60, 60],
+          [180, 60], [180, 30], [150, 0], [180, -30], [180, -60], [60, -60], [-60, -60], [-180, -60]
+        ]]}}, {quantization: 8});
+      assert.deepEqual(topology.arcs, [
+        [[0, 5], [7, -1], [-7, -2], [1, 2], [-1, 1]],
+        [[0, 7], [3, 0], [2, 0], [-5, 0]],
+        [[0, 0], [5, 0], [-2, 0], [-3, 0]]
+      ]);
+      assert.deepEqual(topology.objects.polygon, {type: "Polygon", arcs: [[0], [1], [2]]});
     }
   }
 });


### PR DESCRIPTION
I disabled the “quantization precisely preserves minimum and maximum values” test as longitude wrapping changes this slightly.
