### PR TITLE
Move points that are at -180° to +180°

### DIFF
--- a/lib/topojson/quantize.js
+++ b/lib/topojson/quantize.js
@@ -4,7 +4,9 @@ module.exports = function(objects, bbox, Q) {
       x1 = isFinite(bbox[2]) ? bbox[2] : 0,
       y1 = isFinite(bbox[3]) ? bbox[3] : 0,
       kx = x1 - x0 ? (Q - 1) / (x1 - x0) : 1,
-      ky = y1 - y0 ? (Q - 1) / (y1 - y0) : 1;
+      ky = y1 - y0 ? (Q - 1) / (y1 - y0) : 1,
+      antimeridian_neg = Math.round((-180-x0)*kx),
+      antimeridian_pos = Math.round((180-x0)*kx);
 
   function quantizeGeometry(geometry) {
     if (geometry && quantizeGeometryType.hasOwnProperty(geometry.type)) quantizeGeometryType[geometry.type](geometry);
@@ -47,6 +49,7 @@ module.exports = function(objects, bbox, Q) {
   function quantizePoint(coordinates) {
     coordinates[0] = Math.round((coordinates[0] - x0) * kx);
     coordinates[1] = Math.round((coordinates[1] - y0) * ky);
+    if (coordinates[0] === antimeridian_neg) { coordinates[0] = antimeridian_pos;}
   }
 
   function quantizeLine(coordinates) {
@@ -59,11 +62,14 @@ module.exports = function(objects, bbox, Q) {
         py = pi[1] = Math.round((pi[1] - y0) * ky),
         x,
         y;
+if (px === antimeridian_neg) { pi[0] = px = antimeridian_pos; }
+
 
     while (++i < n) {
       pi = coordinates[i];
       x = Math.round((pi[0] - x0) * kx);
       y = Math.round((pi[1] - y0) * ky);
+      if (x === antimeridian_neg) { pi[0] = x = antimeridian_pos;}
       if (x !== px || y !== py) { // skip coincident points
         pj = coordinates[j++];
         pj[0] = px = x;


### PR DESCRIPTION
Detects if a point lies at -180° (within the quantization precision) and flips it to +180°. This ensures that arcs that lie on the antimeridian and differ only in the sign of the longitude will be correctly identified as being equal. This in turn helps with solving the issue of the antimeridian cuts in the north eastern peninsula in Russia (http://stackoverflow.com/questions/19041457/how-can-i-remove-a-line-from-the-110m-topojson-world-map).
