### PR TITLE
Ensure unmatched fragments are closed.

### DIFF
--- a/lib/topojson/stitch.js
+++ b/lib/topojson/stitch.js
@@ -154,6 +154,7 @@ module.exports = function(objects, transform) {
               fragments[endFragment.index] = null;
               fragments.push(fragmentByStart[fragment[0]] = fragmentByEnd[fragment[fragment.length - 1]] = fragment);
             } else {
+              fragment.push(fragment[0]); // close ring
               rings.push(fragment);
             }
           }


### PR DESCRIPTION
If a fragment has no match for either endpoint, it should be included as a closed ring.  Previously, it was not being closed.
