### PR TITLE
make topojson work w/ browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require("fs");
 
-var topojson = module.exports = new Function("topojson", "return " + fs.readFileSync(__dirname + "/topojson.js", "utf8"))();
+var topojson = module.exports = require('./topojson.js');
 topojson.topology = require("./lib/topojson/topology");
 topojson.simplify = require("./lib/topojson/simplify");
 topojson.clockwise = require("./lib/topojson/clockwise");

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "geojson": "./bin/geojson"
   },
   "scripts": {
-    "test": "./node_modules/.bin/vows && echo"
+    "test": "vows && echo"
   }
 }

--- a/topojson.js
+++ b/topojson.js
@@ -1,4 +1,17 @@
-topojson = (function() {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like enviroments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser global (root is window)
+    root.topojson = factory();
+  }
+}(this, function() {
 
   function merge(topology, arcs) {
     var fragmentByStart = {},
@@ -452,4 +465,4 @@ topojson = (function() {
     neighbors: neighbors,
     presimplify: presimplify
   };
-})();
+}));


### PR DESCRIPTION
I was trying to play with planetary.js today but found out that topojson doesn't work with browserify: https://github.com/BinaryMuse/planetary.js/issues/1

This PR wraps `topojson.js` in https://github.com/umdjs/umd/blob/master/returnExports.js#L40-L60, which gets rid of the `fs.readFileSync` in `index.js`, which gets rid of the need to use the `brfs` transform for use w/ browserify.

If you don't like this PR I can alternatively make a PR w/ https://github.com/maxogden/topojson/commit/bb1d7959f689a45ad129de061c7f012a58c4ad6d, which only modifies `package.json` and also makes this module work with browserify. 

In my opinion this PR is less complex overall than requiring `brfs` for browserification

Cheers!
