### PR TITLE
Fix filtering of small polygons with holes.

### DIFF
--- a/lib/topojson/filter.js
+++ b/lib/topojson/filter.js
@@ -56,17 +56,21 @@ module.exports = function(topology, options) {
   prune(topology, options);
 
   function filterPolygon(arcs) {
-    return ringArea(arcs[0]) // if the exterior is small, ignore any holes
-        ? [arcs.shift()].concat(arcs.filter(ringArea))
+    return filterExteriorRing(arcs[0]) // if the exterior is small, ignore any holes
+        ? [arcs.shift()].concat(arcs.filter(filterInteriorRing))
         : null;
   }
 
+  function filterExteriorRing(ring) {
+    return system.absoluteArea(ringArea(ring)) >= minimumArea;
+  }
+
+  function filterInteriorRing(ring) {
+    return system.absoluteArea(-ringArea(ring)) >= minimumArea;
+  }
+
   function ringArea(ring) {
-    var topopolygon = {type: "Polygon", arcs: [ring]},
-        geopolygon = topojson.feature(topology, topopolygon),
-        exterior = geopolygon.geometry.coordinates[0],
-        exteriorArea = system.absoluteArea(system.ringArea(exterior));
-    return exteriorArea >= minimumArea;
+    return system.ringArea(topojson.feature(topology, {type: "Polygon", arcs: [ring]}).geometry.coordinates[0]);
   }
 };
 


### PR DESCRIPTION
(Or, the unusual case of Bora Bora.) When filtering polygons, the old implementation could filter the exterior ring of a polygon but keep its interior rings, thus promoting the first interior ring to the exterior!
