### PR TITLE
If desired, stitch poles before projecting.

### DIFF
--- a/bin/topojson
+++ b/bin/topojson
@@ -248,9 +248,12 @@ function output(error) {
   };
 
   // Reproject (and force inputs to be clockwise before projecting, if needed).
-  if (argv.projection) for (var key in objects) {
-    if (!!argv["force-clockwise"]) topojson.clockwise(objects[key], {"verbose": true, "coordinate-system": "spherical"});
-    objects[key] = d3.geo.project(objects[key], argv.projection);
+  if (argv.projection) {
+    if (!!argv["stitch-poles"]) topojson.stitch(objects);
+    for (var key in objects) {
+      if (!!argv["force-clockwise"]) topojson.clockwise(objects[key], {"verbose": true, "coordinate-system": "spherical"});
+      objects[key] = d3.geo.project(objects[key], argv.projection);
+    }
   }
 
   // Convert GeoJSON to TopoJSON.

--- a/index.js
+++ b/index.js
@@ -5,3 +5,4 @@ topojson.clockwise = require("./lib/topojson/clockwise");
 topojson.filter = require("./lib/topojson/filter");
 topojson.prune = require("./lib/topojson/prune");
 topojson.bind = require("./lib/topojson/bind");
+topojson.stitch = require("./lib/topojson/stitch");


### PR DESCRIPTION
When a projection is specified, the topology is constructed in Cartesian coordinates after the projection is applied, so pole stitching is implicitly disabled. Instead, we must stitch poles before the projection is applied. This fixes the remaining issue in mbostock/d3#1802.
