### PR TITLE
Preserve shared properties of merged arcs

### DIFF
--- a/bin/topojson-merge
+++ b/bin/topojson-merge
@@ -58,8 +58,23 @@ topology.objects[argv.oo] = argv.k ? {
       .entries(topology.objects[argv.io].geometries)
       .map(function(entry) {
         var polygon = topojson.mergeArcs(topology, entry.values),
-            id = argv.k(entry.values[0]);
+            id = argv.k(entry.values[0]),
+            properties = entry.values[0].properties;
         if (id != null) polygon.id = id;
+        if (properties != null) {
+          entry.values.forEach(function(geometry) {
+            for (var key in geometry.properties) {
+              if (key in properties) {
+                if (properties[key] !== geometry.properties[key]) {
+                  properties[key] = undefined;
+                }
+              } else {
+                properties[key] = geometry.properties[key];
+              }
+            }
+          });
+          polygon.properties = properties;
+        }
         return polygon;
       })
 } : topojson.mergeArcs(topology, topology.objects[argv.io].geometries);


### PR DESCRIPTION
It would be nice if `topojson-merge` also preserved shared properties like `topojson-group`.

Example: Swiss lakes are split into multiple features in the source shapefile, and I'd like to preserve the name property on the merged lake.

![lac-leman](https://cloud.githubusercontent.com/assets/70969/2622162/d23da502-bc92-11e3-954c-bc318e699a99.png)
