### PR TITLE
Simplify each arc separately.

### DIFF
--- a/topojson.js
+++ b/topojson.js
@@ -349,14 +349,14 @@
   function presimplify(topology, triangleArea) {
     var absolute = transformAbsolute(topology.transform),
         relative = transformRelative(topology.transform),
-        heap = minAreaHeap(),
-        maxArea = 0,
-        triangle;
+        heap = minAreaHeap();
 
     if (!triangleArea) triangleArea = cartesianTriangleArea;
 
     topology.arcs.forEach(function(arc) {
-      var triangles = [];
+      var triangles = [],
+          maxArea = 0,
+          triangle;
 
       arc.forEach(absolute);
 
@@ -375,33 +375,31 @@
         triangle.previous = triangles[i - 1];
         triangle.next = triangles[i + 1];
       }
-    });
 
-    while (triangle = heap.pop()) {
-      var previous = triangle.previous,
-          next = triangle.next;
+      while (triangle = heap.pop()) {
+        var previous = triangle.previous,
+            next = triangle.next;
 
-      // If the area of the current point is less than that of the previous point
-      // to be eliminated, use the latter's area instead. This ensures that the
-      // current point cannot be eliminated without eliminating previously-
-      // eliminated points.
-      if (triangle[1][2] < maxArea) triangle[1][2] = maxArea;
-      else maxArea = triangle[1][2];
+        // If the area of the current point is less than that of the previous point
+        // to be eliminated, use the latter's area instead. This ensures that the
+        // current point cannot be eliminated without eliminating previously-
+        // eliminated points.
+        if (triangle[1][2] < maxArea) triangle[1][2] = maxArea;
+        else maxArea = triangle[1][2];
 
-      if (previous) {
-        previous.next = next;
-        previous[2] = triangle[2];
-        update(previous);
+        if (previous) {
+          previous.next = next;
+          previous[2] = triangle[2];
+          update(previous);
+        }
+
+        if (next) {
+          next.previous = previous;
+          next[0] = triangle[0];
+          update(next);
+        }
       }
 
-      if (next) {
-        next.previous = previous;
-        next[0] = triangle[0];
-        update(next);
-      }
-    }
-
-    topology.arcs.forEach(function(arc) {
       arc.forEach(relative);
     });
 


### PR DESCRIPTION
Rather than build one large heap for all arcs, we build a heap for each arc separately and simplify one arc at a time.  A quick benchmark using Natural Earth’s 10m admin-0 data simplified at 1e-5 results in a 2x speedup with this change.  This is due to reduced peak memory usage and faster heap operations on the smaller heaps.

~~Note that this does modify the output slightly, because Visvalingam’s algorithm ensures the effective areas of points are always greater or equal to the previously-eliminated points, and this modification changes the previously-eliminated points, due to operating on the points from each arc separately.~~

~~However, this aspect is only really important on a per-arc basis, since it prevents initially important points from being considered unimportant later on, i.e. if  eliminated points result in a smaller effective area.~~
