### PR TITLE
Remove coincident arcs from rings.

### DIFF
--- a/lib/topojson/topology/index.js
+++ b/lib/topojson/topology/index.js
@@ -29,9 +29,26 @@ module.exports = function(objects) {
     GeometryCollection: function(o) { o.geometries.forEach(indexGeometry); },
     LineString: function(o) { o.arcs = indexArcs(o.arcs); },
     MultiLineString: function(o) { o.arcs = o.arcs.map(indexArcs); },
-    Polygon: function(o) { o.arcs = o.arcs.map(indexArcs); },
-    MultiPolygon: function(o) { o.arcs = o.arcs.map(indexMultiArcs); }
+    Polygon: function(o) { o.arcs = o.arcs.map(indexRingArcs); },
+    MultiPolygon: function(o) { o.arcs = o.arcs.map(indexMultiRingArcs); }
   };
+
+  function indexRingArcs(arc) {
+    var lastIndex,
+        indexes = [],
+        length = -1;
+    do {
+      var index = indexByArc.get(arc);
+      if (index === lastIndex) indexes.length = length; // coincident arcs
+      else indexes.push(arc[0] < arc[1] ? index : ~index), lastIndex = index, ++length;
+    } while (arc = arc.next);
+    return indexes;
+  }
+
+  function indexMultiRingArcs(arcs) {
+    return arcs.map(indexRingArcs);
+  }
+
 
   function indexArcs(arc) {
     var indexes = [];

--- a/lib/topojson/topology/index.js
+++ b/lib/topojson/topology/index.js
@@ -1,7 +1,8 @@
 var hashmap = require("./hashmap"),
     extract = require("./extract"),
     cut = require("./cut"),
-    dedup = require("./dedup");
+    dedup = require("./dedup"),
+    topojson = require("../../../");
 
 // Constructs the TopoJSON Topology for the specified hash of geometries.
 // Each object in the specified hash must be a GeoJSON object,
@@ -29,26 +30,19 @@ module.exports = function(objects) {
     GeometryCollection: function(o) { o.geometries.forEach(indexGeometry); },
     LineString: function(o) { o.arcs = indexArcs(o.arcs); },
     MultiLineString: function(o) { o.arcs = o.arcs.map(indexArcs); },
-    Polygon: function(o) { o.arcs = o.arcs.map(indexRingArcs); },
-    MultiPolygon: function(o) { o.arcs = o.arcs.map(indexMultiRingArcs); }
+    Polygon: function(o) {
+      o.arcs = o.arcs.map(indexArcs);
+      var m = topojson.mergeArcs(topology, [o]);
+      o.type = m.type;
+      o.arcs = m.arcs;
+    },
+    MultiPolygon: function(o) {
+      o.arcs = o.arcs.map(indexMultiArcs);
+      var m = topojson.mergeArcs(topology, [o]);
+      o.type = m.type;
+      o.arcs = m.arcs;
+    }
   };
-
-  function indexRingArcs(arc) {
-    var lastIndex,
-        indexes = [],
-        length = -1;
-    do {
-      var index = indexByArc.get(arc);
-      if (index === lastIndex) indexes.length = length; // coincident arcs
-      else indexes.push(arc[0] < arc[1] ? index : ~index), lastIndex = index, ++length;
-    } while (arc = arc.next);
-    return indexes;
-  }
-
-  function indexMultiRingArcs(arcs) {
-    return arcs.map(indexRingArcs);
-  }
-
 
   function indexArcs(arc) {
     var indexes = [];


### PR DESCRIPTION
Quantisation can introduce coincident arcs.  If this occurs during pre-quantisation, it can result in awkward topologies, violating assumptions made by topojson.mergeArcs.

Related discussion in #164.

_Edit: I think it would be better to pick an appropriate pre-quantisation level, as removing coincident arcs doesn’t seem to fix all problems._
