### PR TITLE
Revert "Workaround for presimplify bug in Chrome."

### DIFF
--- a/topojson.js
+++ b/topojson.js
@@ -358,14 +358,7 @@
           maxArea = 0,
           triangle;
 
-      // To store each point’s effective area, we create a new array rather than
-      // extending the passed-in point to workaround a Chrome/V8 bug (getting
-      // stuck in smi mode). For midpoints, the initial effective area of
-      // Infinity will be computed in the next step.
-      for (var i = 0, n = arc.length, p; i < n; ++i) {
-        p = arc[i];
-        absolute(arc[i] = [p[0], p[1], Infinity], i);
-      }
+      arc.forEach(absolute);
 
       for (var i = 1, n = arc.length - 1; i < n; ++i) {
         triangle = arc.slice(i - 1, i + 2);
@@ -373,6 +366,9 @@
         triangles.push(triangle);
         heap.push(triangle);
       }
+
+      // Always keep the arc endpoints!
+      arc[0][2] = arc[n][2] = Infinity;
 
       for (var i = 0, n = triangles.length; i < n; ++i) {
         triangle = triangles[i];


### PR DESCRIPTION
This bug was fixed and rolled out in V8 versions 3.27.34.17 and
3.28.71.7, hence the fix has been in Chrome Stable for some time now
(for all target systems).

More details:

  https://code.google.com/p/v8/issues/detail?id=3529

This reverts commit f66aa3e9e71ab310177b608fc4fe7722c06271a2.

Conflicts:
    topojson.js
