### PR TITLE
Fix topojson-command-test on Linux.

### DIFF
--- a/test/topojson-command-test.js
+++ b/test/topojson-command-test.js
@@ -108,7 +108,7 @@ function testConversion(output, options) {
   return {
     topic: function() {
       var callback = this.callback;
-      child.exec("bin/topojson " + options, function(error, stdout, stderr) {
+      child.exec("bin/topojson " + options + " | cat", function(error, stdout, stderr) {
         callback(error, error ? null : JSON.parse(stdout));
       });
     },


### PR DESCRIPTION
It looks like Node’s child processes cannot always open /dev/stdout, at
least on Linux.  An error such as "UNKNOWN" or "ENXIO" is thrown.

This thread may be related:

  https://groups.google.com/d/topic/nodejs/SxNKLclbM5k/discussion

One workaround is to insert a pipe to cat, which allows the child
process to open /dev/stdout, and pipe to cat.  Then the output of cat
can be read by the test.

Fixes #204.
