### PR TITLE
Remove 'else' before 'this.topojson = topojson'

### DIFF
--- a/topojson.js
+++ b/topojson.js
@@ -530,5 +530,5 @@
 
   if (typeof define === "function" && define.amd) define(topojson);
   else if (typeof module === "object" && module.exports) module.exports = topojson;
-  else this.topojson = topojson;
+  this.topojson = topojson;
 }();


### PR DESCRIPTION
This matches the current d3.js (as of 3.5.5) method of exporting the library.  I was running into trouble on GitHub's Atom-Shell (now called electron) when I tried to use topojson.  It would fail to import correctly by not creating a topojson object.  The error message was:

``` bash
[22095:0503/213544:INFO:CONSOLE(370)] "Uncaught ReferenceError: topojson is not defined", source: file:///homes/rmason/code/menubar/example/index.html (370)
```

and was included in index.html as follows:

``` html
<script src="topojson.js"></script>
```

All of the tests still pass:

``` bash
> topojson@1.6.19 test /homes/rmason/code/topojson
> vows; echo

·· ·· ···· ·· ·· ····················· ·············· ···· ··················· ········· ······· ·· ········ ·········· ····· ········ ········ ··· ············ ······································ ······································· ······· ·········· ······ ························· ········································ ···················································· ··
  ✓ OK » 361 honored (5.680s)
```

But it may be helpful to add a test for this case.  I'm not exactly sure what that would entail though as it is hard to search google for this.<moduleName> = <moduleName> and if it is always useful to do this and what the failure modes for it are.
