### PR TITLE
Allow “oversize” spherical input data.

### DIFF
--- a/lib/topojson/topology.js
+++ b/lib/topojson/topology.js
@@ -58,14 +58,15 @@ module.exports = function(objects, options) {
   }
 
   if (system === systems.spherical) {
-    if (oversize) throw new Error("spherical coordinates outside of [±180°, ±90°]");
-
-    // When near the spherical coordinate limits, clamp to nice round values.
-    // This avoids quantized coordinates that are slightly outside the limits.
-    if (bbox[0] < -180 + ε) bbox[0] = -180;
-    if (bbox[1] < -90 + ε) bbox[1] = -90;
-    if (bbox[2] > 180 - ε) bbox[2] = 180;
-    if (bbox[3] > 90 - ε) bbox[3] = 90;
+    if (oversize) console.warn("spherical coordinates outside of [±180°, ±90°]");
+    else {
+      // When near the spherical coordinate limits, clamp to nice round values.
+      // This avoids quantized coordinates that are slightly outside the limits.
+      if (bbox[0] < -180 + ε) bbox[0] = -180;
+      if (bbox[1] < -90 + ε) bbox[1] = -90;
+      if (bbox[2] > 180 - ε) bbox[2] = 180;
+      if (bbox[3] > 90 - ε) bbox[3] = 90;
+    }
   }
 
   if (verbose) {


### PR DESCRIPTION
Rather than throwing an error, a warning is shown if --spherical has
been specified.  Some inputs may contain coordinates outside the
expected ±180° longitudinal bounds (typically to support polygons that
cross the antimeridian).  It would be unexpected for latitudes to be
outside ±90°, but perhaps we should allow it anyway.
