### PR TITLE
Fix delta to preserve altitude

### DIFF
--- a/lib/topojson/delta.js
+++ b/lib/topojson/delta.js
@@ -16,10 +16,12 @@ module.exports = function(topology) {
         x1,
         y1;
     while (++j < m) {
-      point = arc[j];
+      point = arc[j].slice();
+      arc[j] = point;
       x1 = point[0];
       y1 = point[1];
-      arc[j] = [x1 - x0, y1 - y0];
+      point[0] = x1 - x0;
+      point[1] = y1 - y0;
       x0 = x1;
       y0 = y1;
     }

--- a/test/delta-test.js
+++ b/test/delta-test.js
@@ -27,6 +27,17 @@ suite.addBatch({
       }).arcs, [
         [[0, 0], [9999, 0], [0, 0], [-9999, 9999], [0, -9999]]
       ]);
+    },
+    "preserves additional positition elements": function() {
+      assert.deepEqual(delta({
+        type: "Topology",
+        arcs: [
+          [[0, 0, 1], [9999, 0, 2], [9999, 0, 3], [0, 9999, 4], [0, 0, 5, false]]
+        ],
+        objects: {}
+      }).arcs, [
+        [[0, 0, 1], [9999, 0, 2], [0, 0, 3], [-9999, 9999, 4], [0, -9999, 5, false]]
+      ]);
     }
   }
 });


### PR DESCRIPTION
The `delta` function only preserves the first two numbers in a position.

Given

``` javascript
var topojson = require('topojson');
var collection = {
  type: 'FeatureCollection',
  features: [{
    type: 'Feature',
    geometry: {
      type: 'LineString',
      coordinates: [[-71.112886, 42.39387, 13.5], [-71.112874, 42.393889, 13.4]]
    }
  }]
}; // GeoJSON

var topology = topojson.topology({collection: collection}); // convert to TopoJSON
console.log(JSON.stringify(topology)); // inspect TopoJSON
```

The result is

``` json
[[0,0,13.5],[9999,9999]]
```
