### PR TITLE
fixing requirejs dependency injection with datamaps

### DIFF
--- a/topojson.js
+++ b/topojson.js
@@ -528,7 +528,14 @@
 
   function noop() {}
 
-  if (typeof define === "function" && define.amd) define(topojson);
-  else if (typeof module === "object" && module.exports) module.exports = topojson;
-  else this.topojson = topojson;
+  if (typeof define === "function" && define.amd) {
+      define("topojson", [], function() {
+          return topojson;
+      });
+  }
+
+  if (typeof module === "object" && module.exports) module.exports = topojson;
+  if (typeof window === "object") window.topojson = topojson;
+
+  return topojson;
 }();


### PR DESCRIPTION
This will help solving the [issue#49](https://github.com/markmarkoh/datamaps/issues/49) which is about loading topojson as dependency injecting with datamaps.

It's exposing the topojson object to the global scope if window object is defined.
I've followed the jQuery way to do it. it solved the problem for me.
