### PR TITLE
Workaround for polys with undefined coordinates

### DIFF
--- a/lib/topojson/geomify.js
+++ b/lib/topojson/geomify.js
@@ -75,7 +75,7 @@ module.exports = function(objects) {
       }
     },
     Polygon: function(o) {
-      for (var rings = o.coordinates, i = 0, N = 0, n = rings.length; i < n; ++i) {
+      for (var rings = o.coordinates || [], i = 0, N = 0, n = rings.length; i < n; ++i) {
         var ring = rings[i];
         if (ring.length) rings[N++] = ring;
       }


### PR DESCRIPTION
The shapefiles from the Australian 2006 Census for NSW, when fed into topojson, result in a few polygons that have `o.coordinates === undefined`.

This is a minimal change to guard against that possibly bad input data and allow topojson to successfully process the shapefile.

If you're curious, the .shp file was downloaded from here:

http://www.abs.gov.au/AUSSTATS/abs@.nsf/DetailsPage/1209.0.55.0022006?OpenDocument
