### PR TITLE
Fix #304 - remove re-export of binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ As a result, TopoJSON is substantially more compact than GeoJSON, frequently off
 
 ## Installing
 
-If you use NPM, `npm install topojson`. Otherwise, download the [latest release](https://github.com/topojson/topojson/releases/latest). You can also load directly from [d3js.org](https://d3js.org) as a [standalone library](https://d3js.org/topojson.v2.min.js). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `topojson` global is exported:
+If you use NPM, `npm install topojson`. Otherwise, download the [latest release](https://github.com/topojson/topojson/releases/latest). You can also load directly from [d3js.org](https://d3js.org) as a [standalone library](https://unpkg.com/topojson@3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `topojson` global is exported:
 
 ```html
-<script src="https://d3js.org/topojson.v2.min.js"></script>
+<script src="https://unpkg.com/topojson@3"></script>
 <script>
 
 var topology = topojson.topology({foo: geojson});
@@ -29,6 +29,7 @@ var topology = topojson.topology({foo: geojson});
 ### Generation (topojson-server)
 
 * [topojson.topology](https://github.com/topojson/topojson-server/blob/master/README.md#topology) - convert GeoJSON to TopoJSON.
+* [geo2topo](https://github.com/topojson/topojson-server/blob/master/README.md#geo2topo) - convert GeoJSON to TopoJSON.
 
 ### Simplification (topojson-simplify)
 
@@ -42,6 +43,7 @@ var topology = topojson.topology({foo: geojson});
 * [topojson.planarTriangleArea](https://github.com/topojson/topojson-simplify/blob/master/README.md#planarTriangleArea) - compute the planar area of a triangle.
 * [topojson.sphericalRingArea](https://github.com/topojson/topojson-simplify/blob/master/README.md#sphericalRingArea) - compute the spherical area of a ring.
 * [topojson.sphericalTriangleArea](https://github.com/topojson/topojson-simplify/blob/master/README.md#sphericalTriangleArea) - compute the spherical area of a triangle.
+* [toposimplify](https://github.com/topojson/topojson-simplify/blob/master/README.md#toposimplify) - simplify TopoJSON, removing coordinates.
 
 ### Manipulation (topojson-client)
 
@@ -55,11 +57,6 @@ var topology = topojson.topology({foo: geojson});
 * [topojson.quantize](https://github.com/topojson/topojson-client/blob/master/README.md#quantize) - round coordinates, reducing precision.
 * [topojson.transform](https://github.com/topojson/topojson-client/blob/master/README.md#transform) - remove delta-encoding and apply a transform.
 * [topojson.untransform](https://github.com/topojson/topojson-client/blob/master/README.md#untransform) - apply delta-encoding and remove a transform.
-
-## Command-Line Reference
-
-* [geo2topo](https://github.com/topojson/topojson-server/blob/master/README.md#geo2topo) - convert GeoJSON to TopoJSON.
-* [toposimplify](https://github.com/topojson/topojson-simplify/blob/master/README.md#toposimplify) - simplify TopoJSON, removing coordinates.
 * [topo2geo](https://github.com/topojson/topojson-client/blob/master/README.md#topo2geo) - convert TopoJSON to GeoJSON.
 * [topomerge](https://github.com/topojson/topojson-client/blob/master/README.md#topomerge) - merge TopoJSON geometry, and optionally filter.
 * [topoquantize](https://github.com/topojson/topojson-client/blob/master/README.md#topoquantize) - round TopoJSON, reducing precision.

--- a/package.json
+++ b/package.json
@@ -20,30 +20,23 @@
     "type": "git",
     "url": "https://github.com/topojson/topojson.git"
   },
-  "bin": {
-    "geo2topo": "node_modules/topojson-server/bin/geo2topo",
-    "toposimplify": "node_modules/topojson-simplify/bin/toposimplify",
-    "topo2geo": "node_modules/topojson-client/bin/topo2geo",
-    "topomerge": "node_modules/topojson-client/bin/topomerge",
-    "topoquantize": "node_modules/topojson-client/bin/topoquantize"
-  },
   "scripts": {
     "pretest": "rm -rf dist && mkdir dist && node rollup.node",
     "test": "tape 'test/**/*-test.js'",
     "prepublish": "npm run test && rollup -c --banner \"$(preamble)\" -f umd -n topojson -o dist/topojson.js -- index.js && uglifyjs --preamble \"$(preamble)\" dist/topojson.js -c negate_iife=false -m -o dist/topojson.min.js",
-    "postpublish": "VERSION=`node -e 'console.log(require(\"./package.json\").version)'`; git push && git push --tags && cp -v README.md LICENSE.md dist/topojson.js dist/topojson.min.js ../topojson-bower && cd ../topojson-bower && git add README.md LICENSE.md topojson.js topojson.min.js && git commit -m \"Release $VERSION.\" && git tag -am \"Release $VERSION.\" v${VERSION} && git push && git push --tags && cd - && cp dist/topojson.js ../d3.github.com/topojson.v2.js && cp dist/topojson.min.js ../d3.github.com/topojson.v2.min.js && cd ../d3.github.com && git add topojson.v2.js topojson.v2.min.js && git commit -m \"topojson ${VERSION}\" && git push && cd - && zip -j dist/topojson.zip -- LICENSE.md README.md dist/topojson.js dist/topojson.min.js"
+    "postpublish": "git push && git push --tags && cp -v README.md LICENSE.md dist/topojson.js dist/topojson.min.js ../topojson-bower && cd ../topojson-bower && git add README.md LICENSE.md topojson.js topojson.min.js && git commit -m \"${npm_package_version}\" && git tag -am \"${npm_package_version}\" v${npm_package_version} && git push && git push --tags && cd - && cp dist/topojson.js ../d3.github.com/topojson.v3.js && cp dist/topojson.min.js ../d3.github.com/topojson.v3.min.js && cd ../d3.github.com && git add topojson.v3.js topojson.v3.min.js && git commit -m \"topojson ${npm_package_version}\" && git push && cd - && zip -j dist/topojson.zip -- LICENSE.md README.md dist/topojson.js dist/topojson.min.js"
   },
   "devDependencies": {
     "package-preamble": "0.0",
-    "rollup": "0.36",
+    "rollup": "0.41",
     "rollup-plugin-ascii": "0.0",
     "rollup-plugin-node-resolve": "2",
     "tape": "4",
     "uglify-js": "2"
   },
   "dependencies": {
-    "topojson-client": "2.1.0",
-    "topojson-server": "2.0.0",
-    "topojson-simplify": "2.0.0"
+    "topojson-client": "3.0.0",
+    "topojson-server": "3.0.0",
+    "topojson-simplify": "3.0.0"
   }
 }


### PR DESCRIPTION
You must now install the TopoJSON submodules to have these binaries.